### PR TITLE
Only use SSL when accessing Icinga if the Url is HTTPS

### DIFF
--- a/jobs/icinga.rb
+++ b/jobs/icinga.rb
@@ -109,7 +109,7 @@ def request_status(url, user, pass, type)
   uri = URI.parse(url + "?" + url_part + "&nostatusheader&jsonoutput&sorttype=1&sortoption=6")
 
   http = Net::HTTP.new(uri.host, uri.port)
-  http.use_ssl = true
+  http.use_ssl = uri.scheme == 'https'
   http.verify_mode = OpenSSL::SSL::VERIFY_NONE
   request = Net::HTTP::Get.new(uri.request_uri)
   if (user and pass)


### PR DESCRIPTION
Hello,
My Icinga server is only available via HTTP.  When the scheduled job tries to access it I would always get an SSL error, which I traced to the line below.  I've changed it so that it only uses SSL if talking to Icinga via HTTPS.
This works fine for me and I believe this will also be fine for the HTTPS case (however I must admit I don't have a means to explicitly test this).

Let me know if you have any questions :smile: 
Usman
